### PR TITLE
Plugin Request Form

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin_request.yml
+++ b/.github/ISSUE_TEMPLATE/plugin_request.yml
@@ -15,8 +15,6 @@ body:
     attributes:
       label: More info
       description: "You can get more specific or put technical information here.\nFeel free to also add context, mockups or anything else here."
-    validations:
-      required: true
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/plugin_request.yml
+++ b/.github/ISSUE_TEMPLATE/plugin_request.yml
@@ -7,8 +7,7 @@ body:
     id: plugin-description
     attributes:
       label: Plugin Description
-      description: A clear and concise description of what the plugin would do.
-      Don't get too specific, that's for the next part.
+      description: A clear and concise description of what the plugin would do. \nDon't get too specific, that's for the next part.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/plugin_request.yml
+++ b/.github/ISSUE_TEMPLATE/plugin_request.yml
@@ -1,0 +1,30 @@
+name: Plugin Request
+description: Request a new plugin
+title: "[Request]:"
+labels: ["discussion requested"]
+body:
+  - type: textarea
+    id: plugin-description
+    attributes:
+      label: Plugin Description
+      description: A clear and concise description of what the plugin would do.
+      Don't get too specific, that's for the next part.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-plugin-info
+    attributes:
+      label: More info
+      description: You can get more specific or put technical information here. Feel free to also add context, mockups or anything else here.
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Request Terms
+      description: By submitting this request you have confirmed the following
+      options:
+        - label: I checked if this request wasn't already proposed
+          required: true
+        - label: I made sure this request follows Dalamud's [plugin guidelines](https://github.com/goatcorp/FFXIVQuickLauncher)
+          required: true

--- a/.github/ISSUE_TEMPLATE/plugin_request.yml
+++ b/.github/ISSUE_TEMPLATE/plugin_request.yml
@@ -1,6 +1,5 @@
 name: Plugin Request
 description: Request a new plugin
-title: "[Request]:"
 labels: ["discussion requested"]
 body:
   - type: textarea
@@ -15,6 +14,11 @@ body:
     attributes:
       label: More info
       description: "You can get more specific or put technical information here.\nFeel free to also add context, mockups or anything else here."
+  - type: textarea
+    id: original-requestor
+    attributes:
+      label: Original Requestor
+      description: "If this request is being made on behalf of another user, let us know who!"
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/plugin_request.yml
+++ b/.github/ISSUE_TEMPLATE/plugin_request.yml
@@ -7,14 +7,14 @@ body:
     id: plugin-description
     attributes:
       label: Plugin Description
-      description: A clear and concise description of what the plugin would do. \nDon't get too specific, that's for the next part.
+      description: "A clear and concise description of what the plugin would do.\nDon't get too specific, that's for the next part."
     validations:
       required: true
   - type: textarea
     id: additional-plugin-info
     attributes:
       label: More info
-      description: You can get more specific or put technical information here. Feel free to also add context, mockups or anything else here.
+      description: "You can get more specific or put technical information here.\nFeel free to also add context, mockups or anything else here."
     validations:
       required: true
   - type: checkboxes


### PR DESCRIPTION
Converted the plugin request template to a plugin request form using the [github forms beta](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms). Might be a little more user friendly for people to create suggestions since average users likely don't know markdown.

Plus it keeps the formatting because sometimes people just ignore the template and delete everything to craft their own post. 😅 

![image](https://user-images.githubusercontent.com/39720490/163828912-03579949-75cc-4cdf-845a-5b016bb5957f.png)
